### PR TITLE
Fix the normalizing vector in compute-lid.py

### DIFF
--- a/additional-scripts/compute-lid.py
+++ b/additional-scripts/compute-lid.py
@@ -11,13 +11,14 @@ k = 100
 if len(sys.argv) == 3:
     k = int(sys.argv[2])
 
+print("Using k=", k, file=sys.stderr)
 distances = numpy.array(f['distances'])
 
 estimates = []
 
 for i, vec in enumerate(distances):
     vec.sort()
-    w = vec[-1]
+    w = vec[min(len(vec) - 1, k)]
     half_w = 0.5 * w
     s = 0.0
     valid = 0
@@ -33,8 +34,8 @@ for i, vec in enumerate(distances):
 for i,e in enumerate(estimates):
     print(i, e)
 #print(estimates)
-avg_estimate = sum(estimates) / len(estimates)
-print(sys.argv[1], avg_estimate)
+# avg_estimate = sum(estimates) / len(estimates)
+# print(sys.argv[1], avg_estimate)
 
 
 


### PR DESCRIPTION
Now the distances in the MLE estimator are normalized to the k-th
neighbor, as they should. Before this change, distances were always
normalized to the last vector in the collection of distances, which in
our particular setup was 100. Therefore estimates for k=100 (the ones
used in the paper) are OK, but estimates with a different k are not.

The figure below shows the distribution of LID scores computed for the GLOVE dataset with k=10 and k=100.
The two distributions are very similar

![check](https://user-images.githubusercontent.com/1175603/103364830-04858400-4abf-11eb-8ae7-b8e8c1ae137c.png)
